### PR TITLE
fix(sync): avoid npm.cmd spawn on Windows

### DIFF
--- a/scripts/repository-sync.mjs
+++ b/scripts/repository-sync.mjs
@@ -68,8 +68,7 @@ export function main(argv = process.argv.slice(2)) {
   if (options.skipCheck) {
     console.warn("Проверка content/ пропущена по флагу --no-check")
   } else if (existsSync(validator) && existsSync(packageFile)) {
-    const npm = process.platform === "win32" ? "npm.cmd" : "npm"
-    run(npm, ["run", "content:validate"])
+    run(process.execPath, ["--run", "content:validate"])
   }
 
   run(process.execPath, [corePath(), ...options.forwarded])


### PR DESCRIPTION
## Исправление

На Windows предварительная проверка синхронизации запускалась через `spawnSync("npm.cmd", ...)`, что в PowerShell могло завершаться ошибкой `EINVAL` до запуска npm.

Теперь `repository-sync.mjs` использует текущий `node.exe` и встроенную команду Node.js 22:

```text
node --run content:validate
```

Это сохраняет единый скрипт `content:validate` из `package.json`, но не требует запуска `.cmd`-обёртки через `spawnSync`.

## Проверки

- `npm run content:validate`
- `npm run sync:test`
- `npx quartz build`