### PR TITLE
Exclude Obsidian !Meta directory from Quartz output

### DIFF
--- a/.github/workflows/validate-content-links.yml
+++ b/.github/workflows/validate-content-links.yml
@@ -52,3 +52,13 @@ jobs:
 
       - name: Build Quartz
         run: npx quartz build
+
+      - name: Verify Obsidian metadata is not published
+        shell: bash
+        run: |
+          matches="$(find public \( -path '*/!Meta' -o -path '*/!Meta/*' -o -path '*/%21Meta' -o -path '*/%21Meta/*' \) -print)"
+          if [[ -n "$matches" ]]; then
+            echo "Obsidian metadata was published:"
+            echo "$matches"
+            exit 1
+          fi

--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -13,7 +13,7 @@ configuration:
     - private
     - templates
     - .obsidian
-    - "[!]Meta"
+    - "\\!Meta/**"
   theme:
     fontOrigin: googleFonts
     cdnCaching: true


### PR DESCRIPTION
## Причина

`content/!Meta` используется только Obsidian и не должен попадать на сайт. `unlisted: true` здесь не подходит, потому что такие страницы всё равно публикуются и доступны по прямому URL.

## Решение

- используется нативный `configuration.ignorePatterns` Quartz 5;
- имя с ведущим `!` экранировано как `\\!Meta/**` по синтаксису fast-glob;
- добавлена CI-проверка, что после сборки в `public` отсутствуют пути `!Meta` и `%21Meta`.

Это исключает до парсинга весь каталог: Markdown, изображения, PDF и прочие вложения.